### PR TITLE
Upgraded cake core to 0.18.0

### DIFF
--- a/Cake.DoInDirectory/Cake.DoInDirectory.csproj
+++ b/Cake.DoInDirectory/Cake.DoInDirectory.csproj
@@ -32,9 +32,8 @@
     <DocumentationFile>bin\Release\Cake.DoInDirectory.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Cake.Core.0.13.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Cake.DoInDirectory/packages.config
+++ b/Cake.DoInDirectory/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.13.0" targetFramework="net46" />
+  <package id="Cake.Core" version="0.18.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Hi @pitermarx when I'm using the latest version of Cake [0.18.0](http://cakebuild.net/blog/2017/03/cake-v0.18.0-released) I get the following error when installing Cake.DoInDirectory.

Error: The assembly 'Cake.DoInDirectory, Version=0.1.1.0, Culture=neutral, PublicKeyToken=null' is referencing an older version of Cake.Core (0.13.0). This assembly need to reference at least Cake.Core version 0.16.0. Another option is to downgrade Cake to an earlier version.

Would it be possible to upgrade cake in your project?

